### PR TITLE
Updated libraries to latest versions + Compatibility for jQuery 1.9+

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <html>
   <head>
     <title>Swiftype Faceted Search E-Commerce Store Example</title>
-    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
-    <script type="text/javascript" src="http://twitter.github.com/hogan.js/builds/2.0.0/hogan-2.0.0.js"></script>
+    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <script type="text/javascript" src="https://twitter.github.com/hogan.js/builds/3.0.1/hogan-3.0.1.js"></script>
     <script type="text/javascript" src="jquery.swiftype.autocomplete.js"></script>
     <script type='text/javascript' src='jquery.ba-hashchange.min.js'></script>
     <script type="text/javascript" src="jquery.swiftype.search.js"></script>
@@ -109,7 +109,7 @@
                 status = "",
                 id = encodeURIComponent(label).toLowerCase();
               if (window.searchConfig.facets[field] && window.searchConfig.facets[field].indexOf(label) > -1) {
-                status = ' checked="checked"'
+                status = 'checked="checked"'
               }
 
               facets += '<input type="checkbox"' + status + ' name="' + field + '" value="' + label + '" id="' + id + '"> <label for="' + id + '">' + label + ' (' + count + ')</label><br/>';
@@ -145,12 +145,12 @@
         $('.st-dynamic-facets input[type="checkbox"]').each(function(idx, obj) {
           var
             $checkbox = $(obj),
-            facet = $checkbox.attr('name');
+            facet = $checkbox.prop('name');
           if(!window.searchConfig.facets[facet]) {
             window.searchConfig.facets[facet] = [];
           }
-          if($checkbox.attr('checked')) {
-            window.searchConfig.facets[facet].push($checkbox.attr('value'));
+          if($checkbox.prop('checked')) {
+            window.searchConfig.facets[facet].push($checkbox.prop('value'));
           }
         })
 
@@ -160,17 +160,17 @@
       $facetContainer.on('click', 'a.clear-selection', function(e) {
         e.preventDefault();
         var name = $(this).data('name');
-        $('input[name=' + name + ']').attr('checked', false);
+        $('input[name=' + name + ']').prop('checked', false);
         window.searchConfig.facets[name] = [];
 
         reloadResults();
       });
 
       $('.price-filter').on('click', function(e){
-        if ($(this).attr('checked')) {
+        if ($(this).prop('checked')) {
           // Visually update the checkboxes
-          $('.price-filter').attr('checked', false);
-          $(this).attr('checked', true);
+          $('.price-filter').prop('checked', false);
+          $(this).prop('checked', true);
           // Update the search parameters
           window.searchConfig.price.from = $(this).data('from');
           window.searchConfig.price.to = $(this).data('to');

--- a/jquery.swiftype.autocomplete.js
+++ b/jquery.swiftype.autocomplete.js
@@ -91,7 +91,7 @@
       };
 
       var styles = config.dropdownStylesFunction($this);
-      var $swiftypeWidget = $('<div class="swiftype-widget" />');
+      var $swiftypeWidget = $('<div class="' + config.widgetContainerClass + '" />');
       var $listContainer = $('<div />').addClass(config.suggestionListClass).appendTo($swiftypeWidget).css(styles).hide();
       $swiftypeWidget.appendTo(config.autocompleteContainingElement);
       var $list = $('<' + config.suggestionListType + ' />').appendTo($listContainer);
@@ -210,6 +210,10 @@
         $listContainer.css(config.dropdownStylesFunction($this));
       };
 
+      $(window).resize(function (event) {
+        $this.styleDropdown();
+      });
+
       $this.keydown(function (event) {
         $this.styleDropdown();
         // enter = 13; up = 38; down = 40; esc = 27
@@ -307,6 +311,7 @@
     params['sort_field'] = handleFunctionParam(config.sortField);
     params['sort_direction'] = handleFunctionParam(config.sortDirection);
     params['per_page'] = config.resultLimit;
+    params['highlight_fields'] = handleFunctionParam(config.highlightFields);
 
     var endpoint = Swiftype.root_url + '/api/v1/public/engines/suggest.json';
     $this.currentRequest = $.ajax({
@@ -314,7 +319,7 @@
       dataType: 'jsonp',
       url: endpoint,
       data: params
-    }).success(function(data) {
+    }).done(function(data) {
       var norm = normalize(term);
       if (data.record_count > 0) {
         $this.cache.put(norm, data.records);
@@ -425,13 +430,13 @@
     return undefined;
   };
 
-  // simple client-side LRU Cache, based on https://github.com/rsms/js-lru
+	// simple client-side LRU Cache, based on https://github.com/rsms/js-lru
 
-  function LRUCache(limit) {
-    this.size = 0;
-    this.limit = limit;
-    this._keymap = {};
-  }
+	function LRUCache(limit) {
+	  this.size = 0;
+	  this.limit = limit;
+	  this._keymap = {};
+	}
 
   LRUCache.prototype.put = function (key, value) {
     var entry = {
@@ -536,6 +541,7 @@
     sortField: undefined,
     sortDirection: undefined,
     fetchFields: undefined,
+    highlightFields: undefined,
     noResultsClass: 'noResults',
     noResultsMessage: undefined,
     onComplete: defaultOnComplete,
@@ -549,7 +555,8 @@
     setWidth: true,
     typingDelay: 80,
     disableAutocomplete: false,
-    autocompleteContainingElement: 'body'
+    autocompleteContainingElement: 'body',
+    widgetContainerClass: 'swiftype-widget'
   };
 
 })(jQuery);


### PR DESCRIPTION
jQuery 1.9 changed the behavior of .attr(), which breaks the example code. Changed .attr() to .prop() to get it working in later versions of jQuery.
https://jquery.com/upgrade-guide/1.9/#attr-versus-prop-

Similarly, updated our jQuery plugins to the latest versions–this adds support for highlightFields and jQuery 3.0+ compatibility.

tl;dr: Made example compatible with the latest versions of jQuery. 