### PR TITLE
UI/UX suggestions

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -29,7 +29,8 @@ form label {
 }
 
 form input {
-  width: 162px !important; background: #fff;
+  width: 100%;
+  background: #fff;
   border: 1px solid #fff !important;
   border-radius: 4px;
   -webkit-border-radius: 4px;

--- a/custom.css
+++ b/custom.css
@@ -29,7 +29,7 @@ form label {
 }
 
 form input {
-  width: 100%;
+  width: 100% !important;
   background: #fff;
   border: 1px solid #fff !important;
   border-radius: 4px;

--- a/index.html
+++ b/index.html
@@ -93,6 +93,7 @@
       var $facetContainer = $('.st-dynamic-facets');
 
       var reloadResults = function() {
+        window.location.hash = window.location.hash.replace(/stp=[^&]*/i, 'stp=1'); // Reset to page 1
         $(window).hashchange();
       };
 

--- a/index.html
+++ b/index.html
@@ -209,6 +209,15 @@
       $('#st-search-input').swiftype({
         engineKey: 't2s8T3sUKx4jJoebs73L'
       });
+
+      // Start the demo out with products loaded on the page
+      $(window).on('load', function() {
+        var hasSearchTerm = window.location.hash.indexOf('stq=') >= 0;
+        if (!hasSearchTerm) {
+          window.location.hash = 'stq=product&stp=1';
+          reloadResults();
+        }
+      })
     </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <h1>Swiftype Faceted Search E-Commerce Store Example</h1>
     <form>
       <label>Search products</label>
-      <input type='text' id='st-search-input' class='st-search-input' />
+      <input type='text' id='st-search-input' class='st-search-input' placeholder="Search by typing (ex. 'product') and pressing enter" aria-label="Search by typing (ex. 'product') and pressing enter" />
     </form>
     <div id="menu">
       <h3>Sorted by</h3>

--- a/index.html
+++ b/index.html
@@ -203,7 +203,8 @@
         sortDirection: readSortDirection,
         facets: { products: ['category', 'tags'] },
         filters: readFilters,
-        postRenderFunction: bindControls
+        postRenderFunction: bindControls,
+        perPage: 12,
       });
 
       $('#st-search-input').swiftype({

--- a/search.css
+++ b/search.css
@@ -9,7 +9,7 @@ form input.st-search-input {
   font-size: 12px;
   padding: 5px 9px 5px 27px;
   height: 18px;
-  width: 100%;
+  width: 200px;
   color: #666;
   border: 1px solid #ccc;
   outline: none;

--- a/search.css
+++ b/search.css
@@ -9,7 +9,7 @@ form input.st-search-input {
   font-size: 12px;
   padding: 5px 9px 5px 27px;
   height: 18px;
-  width: 200px;
+  width: 100%;
   color: #666;
   border: 1px solid #ccc;
   outline: none;


### PR DESCRIPTION
## Description of changes

### 1 & 2. Add placeholder to search box with instructions + Initialize page load with results

Adding instructional text on how to get product/results cards showing provides some helpful UI affordance and prevents potential confusion around whether the demo is working properly.

While placeholder text is helpful, a far stronger and more compelling demo will have product cards already loaded and facet filters ready to be interacted with. One especial area of confusion to highlight is that the "Prices" facets do nothing on initial page load, thus leading to further lack of clarity on whether the application is working.

**Before:**
<img width="1018" alt="" src="https://user-images.githubusercontent.com/549407/62802677-4c0c0a00-ba9d-11e9-937d-da42e04820a2.png">

**After:**
<img width="1052" alt="Screen Shot 2019-08-09 at 12 00 19 PM" src="https://user-images.githubusercontent.com/549407/62802725-7067e680-ba9d-11e9-9798-abfb737768bd.png">

### 3. Increase product cards per page

This is a minor UI tweak to make the product grid look slightly more balanced on a full page of products.

**Before (left) vs. After (right):**
<img width="1147" alt="" src="https://user-images.githubusercontent.com/549407/62802929-ec622e80-ba9d-11e9-8cff-ff78814a9ce8.png">

### 4. Pagination not being reset on filter

Example scenario:
1. Let's say you're on page 3 of a set of results.
1. You then filter by a tag or facet that only has 1 page of results (e.g., Under $10, tag3)
1. You will now end up with an empty page, and it's confusing as to whether your search experience is broken

Before:
![before](https://user-images.githubusercontent.com/549407/62803283-dbfe8380-ba9e-11e9-93b8-a41cf6755102.gif)

After:
![after](https://user-images.githubusercontent.com/549407/62803287-def97400-ba9e-11e9-9b69-accf77ca2331.gif)
